### PR TITLE
seaLevel function and SI_UNIT selector added

### DIFF
--- a/Adafruit_BMP280.cpp
+++ b/Adafruit_BMP280.cpp
@@ -325,17 +325,23 @@ float Adafruit_BMP280::readAltitude(float seaLevelhPa) {
 
 
 
-/*--------------------------------
+/**************************************************************************/
+/*!
+ 
  sealevel
- args:
- returns pressure at sealevel depending on the  altitude of the pressure reading
- Usefull for weather related sketches
+ args:  pressure = barometric pressure
+        altitude = altitude in [m] of the pressure measurement
+        temp = current temp in [C]
+ 
+ returns pressure at sealevel depending on the altitude and temperature of the pressure reading
+ Usefull for weather related sketches. [kl-git, Jan 2016]
  
  mean sea level barometric pressure = 1013.25 [mbar]
- *--------------------------------*/
-float Adafruit_BMP280::seaLevel(float pressure, float altitude)
+ */
+/**************************************************************************/
+float Adafruit_BMP280::seaLevel(float pressure, float altitude, float temp)
 {
-    return pressure / pow(1-(altitude/44330.0),5.255);
+    return pressure * pow(temp/((temp + 273.15) / ( (temp + 273.15) + 0.0065 * altitude)),5.255);
 }
 
 

--- a/Adafruit_BMP280.cpp
+++ b/Adafruit_BMP280.cpp
@@ -315,12 +315,27 @@ float Adafruit_BMP280::readPressure(void) {
 }
 
 float Adafruit_BMP280::readAltitude(float seaLevelhPa) {
-  float altitude;
 
   float pressure = readPressure(); // in Si units for Pascal
-  pressure /= 100;
+  pressure /= 100;                 // convert to [hPa] = [mbar]
 
-  altitude = 44330 * (1.0 - pow(pressure / seaLevelhPa, 0.1903));
+  return 44330 * (1.0 - pow(pressure / seaLevelhPa, 0.1903));
 
-  return altitude;
 }
+
+
+
+/*--------------------------------
+ sealevel
+ args:
+ returns pressure at sealevel depending on the  altitude of the pressure reading
+ Usefull for weather related sketches
+ 
+ mean sea level barometric pressure = 1013.25 [mbar]
+ *--------------------------------*/
+float Adafruit_BMP280::seaLevel(float pressure, float altitude)
+{
+    return pressure / pow(1-(altitude/44330.0),5.255);
+}
+
+

--- a/Adafruit_BMP280.h
+++ b/Adafruit_BMP280.h
@@ -130,8 +130,8 @@ class Adafruit_BMP280
     float readTemperature(void);
     float readPressure(void);
     float readAltitude(float seaLevelhPa = 1013.25);
-    float seaLevel(float pressure, float altitude);
-
+    float seaLevel(float pressure, float altitude, float temp);
+    
   private:
 
     void readCoefficients(void);

--- a/Adafruit_BMP280.h
+++ b/Adafruit_BMP280.h
@@ -130,6 +130,7 @@ class Adafruit_BMP280
     float readTemperature(void);
     float readPressure(void);
     float readAltitude(float seaLevelhPa = 1013.25);
+    float seaLevel(float pressure, float altitude);
 
   private:
 

--- a/Adafruit_BMP280.h
+++ b/Adafruit_BMP280.h
@@ -31,6 +31,12 @@
  #include <Wire.h>
 #endif
 
+
+#define MBAR    (float)(100.0)
+#define PA      (float)(1.0)
+#define HPA     (float)(100.0)
+
+
 /*=========================================================================
     I2C ADDRESS/BITS
     -----------------------------------------------------------------------*/
@@ -125,6 +131,7 @@ class Adafruit_BMP280
     Adafruit_BMP280(void);
     Adafruit_BMP280(int8_t cspin);
     Adafruit_BMP280(int8_t cspin, int8_t mosipin, int8_t misopin, int8_t sckpin);
+    Adafruit_BMP280(float SI_UNITS);
 
     bool  begin(uint8_t addr = BMP280_ADDRESS);
     float readTemperature(void);
@@ -147,7 +154,8 @@ class Adafruit_BMP280
 
     uint8_t   _i2caddr;
     int32_t   _sensorID;
-    int32_t t_fine;
+    int32_t   t_fine;
+    float     _SI_unit_conversion = PA;
 
     int8_t _cs, _mosi, _miso, _sck;
 

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit BMP280 Library
-version=1.0.2
+version=1.0.3
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Arduino library for BMP280 sensors.


### PR DESCRIPTION
Hi there,

I am using the Adafruit library for my weatherstation project. The library is missing a basic function "seaLevel" which converts the barometric pressure at an altitude to sea level.

Another change I would like to propose: change the basis SI unit of the BMP280 (which currently defaults to [Pa]), which is not the default in Europe. Thus it would be nice to init the BMP280 object with a different SI unit for barometric pressure: [mbar], [hPa] or [Pa]. [Pa] is the default, thus no compatibility issues for existing sketches.

Hope you like this,

Klaus
