### PR TITLE
Reworked for combined T-P burst reads (see DS 3.10).

### DIFF
--- a/Adafruit_BMP280.cpp
+++ b/Adafruit_BMP280.cpp
@@ -206,7 +206,7 @@ uint32_t Adafruit_BMP280::read24(byte reg)
     Wire.write((uint8_t)reg);
     Wire.endTransmission();
     Wire.requestFrom((uint8_t)_i2caddr, (byte)3);
-    
+
     value = Wire.read();
     value <<= 8;
     value |= Wire.read();
@@ -218,7 +218,7 @@ uint32_t Adafruit_BMP280::read24(byte reg)
       SPI.beginTransaction(SPISettings(500000, MSBFIRST, SPI_MODE0));
     digitalWrite(_cs, LOW);
     spixfer(reg | 0x80); // read, bit 7 high
-    
+
     value = spixfer(0);
     value <<= 8;
     value |= spixfer(0);
@@ -314,13 +314,44 @@ float Adafruit_BMP280::readPressure(void) {
   return (float)p/256;
 }
 
-float Adafruit_BMP280::readAltitude(float seaLevelhPa) {
-  float altitude;
+/**************************************************************************/
+/*!
+    Calculates the altitude (in meters) from the specified atmospheric
+    pressure (in hPa), and sea-level pressure (in hPa).
 
-  float pressure = readPressure(); // in Si units for Pascal
-  pressure /= 100;
+    @param  seaLevel      Sea-level pressure in hPa
+    @param  atmospheric   Atmospheric pressure in hPa
+*/
+/**************************************************************************/
+float Adafruit_BMP280::readAltitude(float seaLevel)
+{
+  // Equation taken from BMP180 datasheet (page 16):
+  //  http://www.adafruit.com/datasheets/BST-BMP180-DS000-09.pdf
 
-  altitude = 44330 * (1.0 - pow(pressure / seaLevelhPa, 0.1903));
+  // Note that using the equation from wikipedia can give bad results
+  // at high altitude.  See this thread for more information:
+  //  http://forums.adafruit.com/viewtopic.php?f=22&t=58064
 
-  return altitude;
+  float atmospheric = readPressure() / 100.0F;
+  return 44330.0 * (1.0 - pow(atmospheric / seaLevel, 0.1903));
+}
+
+/**************************************************************************/
+/*!
+    Calculates the pressure at sea level (in hPa) from the specified altitude
+    (in meters), and atmospheric pressure (in hPa).
+    @param  altitude      Altitude in meters
+    @param  atmospheric   Atmospheric pressure in hPa
+*/
+/**************************************************************************/
+float Adafruit_BMP280::seaLevelForAltitude(float altitude, float atmospheric)
+{
+  // Equation taken from BMP180 datasheet (page 17):
+  //  http://www.adafruit.com/datasheets/BST-BMP180-DS000-09.pdf
+
+  // Note that using the equation from wikipedia can give bad results
+  // at high altitude.  See this thread for more information:
+  //  http://forums.adafruit.com/viewtopic.php?f=22&t=58064
+
+  return atmospheric / pow(1.0 - (altitude/44330.0), 5.255);
 }

--- a/Adafruit_BMP280.h
+++ b/Adafruit_BMP280.h
@@ -131,6 +131,10 @@ class Adafruit_BMP280
     float readPressure(void);
     float readAltitude(float seaLevelhPa = 1013.25);
 
+    // function to efficiently read all sensors at once
+    // if a particular pointer is NULL, it is ignored
+    void readAll(float *pTemperature, float *pPressure);
+
   private:
 
     void readCoefficients(void);
@@ -143,6 +147,17 @@ class Adafruit_BMP280
     int16_t   readS16(byte reg);
     uint16_t  read16_LE(byte reg); // little endian
     int16_t   readS16_LE(byte reg); // little endian
+
+    float compensateTemperature(int32_t adc_T);
+    float compensatePressure(int32_t adc_P);
+    typedef struct {
+      uint32_t temp_ADC;
+      uint32_t press_ADC;
+    } UncompensatedData;
+    enum { READ_T, READ_TP };
+    UncompensatedData readSensors(int readType);
+    uint32_t read24I2C(void);
+    uint32_t read24SPI(void);
 
     uint8_t   _i2caddr;
     int32_t   _sensorID;

--- a/Adafruit_BMP280.h
+++ b/Adafruit_BMP280.h
@@ -130,6 +130,7 @@ class Adafruit_BMP280
     float readTemperature(void);
     float readPressure(void);
     float readAltitude(float seaLevelhPa = 1013.25);
+    float seaLevelForAltitude(float altitude, float atmospheric);
 
   private:
 


### PR DESCRIPTION
This deals with the same burst read issue that I reworked in the BME280 library code (PR#14).
It only affects readPressure() so that it can read the temperature used for compensation from the same sample as the pressure. 
Added readAll() to get both T and P from same sample.
