### PR TITLE
Add option to set custom chipid

### DIFF
--- a/Adafruit_BMP280.cpp
+++ b/Adafruit_BMP280.cpp
@@ -37,7 +37,7 @@ Adafruit_BMP280::Adafruit_BMP280(int8_t cspin, int8_t mosipin, int8_t misopin, i
 { }
 
 
-bool Adafruit_BMP280::begin(uint8_t a) {
+bool Adafruit_BMP280::begin(uint8_t a, uint8_t chipid) {
   _i2caddr = a;
 
   if (_cs == -1) {
@@ -58,7 +58,7 @@ bool Adafruit_BMP280::begin(uint8_t a) {
     }
   }
 
-  if (read8(BMP280_REGISTER_CHIPID) != 0x58)
+  if (read8(BMP280_REGISTER_CHIPID) != chipid)
     return false;
 
   readCoefficients();

--- a/Adafruit_BMP280.h
+++ b/Adafruit_BMP280.h
@@ -32,9 +32,10 @@
 #endif
 
 /*=========================================================================
-    I2C ADDRESS/BITS
+    I2C ADDRESS/BITS/SETTINGS
     -----------------------------------------------------------------------*/
     #define BMP280_ADDRESS                (0x77)
+    #define BMP280_CHIPID                 (0x58)
 /*=========================================================================*/
 
 /*=========================================================================
@@ -104,7 +105,7 @@ class Adafruit_BMP280_Unified : public Adafruit_Sensor
   public:
     Adafruit_BMP280_Unified(int32_t sensorID = -1);
 
-    bool  begin(uint8_t addr = BMP280_ADDRESS);
+    bool  begin(uint8_t addr = BMP280_ADDRESS, uint8_t chipid = BMP280_CHIPID);
     void  getTemperature(float *temp);
     void  getPressure(float *pressure);
     float pressureToAltitude(float seaLevel, float atmospheric, float temp);


### PR DESCRIPTION
Some BMP280 versions have different chipid than the currently hardcoded default 0x58. This patch adds the ability to set a custom chipid for the begin() function.

This is done by defining the default CHIPID in the header file and modifying the begin() function so that it gets the default chipid by default. This makes this change fully backwards compatible with all current library users.

I've personally found a BMP280 chip with chipid 0x60