### PR TITLE
Add setStandby() method.

### DIFF
--- a/Adafruit_BMP280.cpp
+++ b/Adafruit_BMP280.cpp
@@ -323,3 +323,16 @@ float Adafruit_BMP280::readAltitude(float seaLevelhPa) {
 
   return altitude;
 }
+
+/**************************************************************************/
+/*!
+  Set the "standby" time in normal mode.  The period between readings.
+  By default if unset this is 0.5ms (2000 Hz) and the chip self-heats.
+*/
+/**************************************************************************/
+void Adafruit_BMP280::setStandby(StandbyTime value) {
+  byte config = read8(BMP280_REGISTER_CONFIG);
+  config &= 0b00011111;
+  config |= value << 5;
+  write8(BMP280_REGISTER_CONFIG, config);
+}

--- a/Adafruit_BMP280.h
+++ b/Adafruit_BMP280.h
@@ -69,6 +69,21 @@
       BMP280_REGISTER_TEMPDATA           = 0xFA,
     };
 
+/*=========================================================================
+    Standby times
+    -----------------------------------------------------------------------*/
+    enum StandbyTime
+    {
+      STANDBY_0_5_MS  = 0b000,
+      STANDBY_62_5_MS = 0b001,
+      STANDBY_125_MS  = 0b010,
+      STANDBY_250_MS  = 0b011,
+      STANDBY_500_MS  = 0b100,
+      STANDBY_1000_MS = 0b101,
+      STANDBY_2000_MS = 0b110,
+      STANDBY_4000_MS = 0b111,
+    };
+
 /*=========================================================================*/
 
 /*=========================================================================
@@ -132,6 +147,7 @@ class Adafruit_BMP280
     float readPressure(void);
     float readAltitude(float seaLevelhPa = 1013.25);
 
+    void setStandby(StandbyTime value);
   private:
 
     void readCoefficients(void);


### PR DESCRIPTION
For setting the standby delay during readings in normal mode.  This library offers no way to switch out of normal mode, and being able to set a slower measurement frequency makes the chip self-heat and alter its readings to a lesser degree.

See data sheet section 3.6.3 _Normal mode_:

> Normal mode continuosly cycles between an (active) measurement period and an (inactive) 
standby period, whose time is defined by tstandby. 

Call like, e.g., `bme.setStandby(StandbyTime::STANDBY_500_MS);`.