### PR TITLE
Fix filter and pressure bitshift

### DIFF
--- a/Adafruit_BMP280.h
+++ b/Adafruit_BMP280.h
@@ -253,7 +253,7 @@ class Adafruit_BMP280
       /** Used to retrieve the assembled config register's byte value. */
       unsigned int get()
       {
-        return (t_sb << 5) | (filter << 3) | spi3w_en;
+        return (t_sb << 5) | (filter << 2) | spi3w_en;
       }
     };
 
@@ -269,7 +269,7 @@ class Adafruit_BMP280
       /** Used to retrieve the assembled ctrl_meas register's byte value. */
       unsigned int get()
       {
-        return (osrs_t << 5) | (osrs_p << 3) | mode;
+        return (osrs_t << 5) | (osrs_p << 2) | mode;
       }
     };
 


### PR DESCRIPTION
Follows the same format as a found error in the BME280 library, see

https://github.com/adafruit/Adafruit_BME280_Library/pull/39

Bosch's own bitmasks can be found here, for reference:

https://github.com/BoschSensortec/BMP280_driver/blob/bmp280_v3.0.0/bmp280_defs.h#L230-L245
