### PR TITLE
Forward declarations and interface reference

### DIFF
--- a/Adafruit_BMP280.cpp
+++ b/Adafruit_BMP280.cpp
@@ -130,7 +130,7 @@ void Adafruit_BMP280::setSampling(sensor_mode mode,
 
 uint8_t Adafruit_BMP280::spixfer(uint8_t x) {
   if (_sck == -1)
-    return SPI.transfer(x);
+    return _spi->transfer(x);
 
   // software spi
   // Serial.println("Software SPI");

--- a/Adafruit_BMP280.h
+++ b/Adafruit_BMP280.h
@@ -33,6 +33,10 @@
   (0x76)                     /**< Alternative I2C address for the sensor. */
 #define BMP280_CHIPID (0x58) /**< Default chip ID. */
 
+//  Forward declarations of Wire and SPI for board/variant combinations that don't have a default 'Wire' or 'SPI' 
+extern TwoWire Wire;
+extern SPIClass SPI;
+
 /*!
  * Registers available on the sensor.
  */

--- a/Adafruit_BMP280.h
+++ b/Adafruit_BMP280.h
@@ -34,8 +34,8 @@
 #define BMP280_CHIPID (0x58) /**< Default chip ID. */
 
 //  Forward declarations of Wire and SPI for board/variant combinations that don't have a default 'Wire' or 'SPI' 
-extern TwoWire Wire;
-extern SPIClass SPI;
+extern TwoWire Wire;  /**< Forward declaration of Wire object */
+extern SPIClass SPI;  /**< Forward declaration of SPI object */
 
 /*!
  * Registers available on the sensor.


### PR DESCRIPTION
When SPI_INTEFACES_COUNT or WIRE_INTERFACES_COUNT is zero, the library fails to compile.  A forward declaration is used to fix this.

There is a direct reference to "SPI" where it should be an indirect reference "_spi->".
