### PR TITLE
updated comments

### DIFF
--- a/Adafruit_BMP280.h
+++ b/Adafruit_BMP280.h
@@ -138,9 +138,9 @@ public:
 
   /** Standby duration in ms */
   enum standby_duration {
-    /** 1 ms standby. */
+    /** 0.5 ms standby. */
     STANDBY_MS_1 = 0x00,
-    /** 63 ms standby. */
+    /** 62.5 ms standby. */
     STANDBY_MS_63 = 0x01,
     /** 125 ms standby. */
     STANDBY_MS_125 = 0x02,


### PR DESCRIPTION
update comments about delay times to match datasheet delay times, but not worth changing the constant names for compatibility reason.