### PR TITLE
Remove Humidity compensation variables

### DIFF
--- a/Adafruit_BMP280.h
+++ b/Adafruit_BMP280.h
@@ -80,13 +80,6 @@ typedef struct {
   int16_t dig_P7;  /**< dig_P7 cal register. */
   int16_t dig_P8;  /**< dig_P8 cal register. */
   int16_t dig_P9;  /**< dig_P9 cal register. */
-
-  uint8_t dig_H1; /**< dig_H1 cal register. */
-  int16_t dig_H2; /**< dig_H2 cal register. */
-  uint8_t dig_H3; /**< dig_H3 cal register. */
-  int16_t dig_H4; /**< dig_H4 cal register. */
-  int16_t dig_H5; /**< dig_H5 cal register. */
-  int8_t dig_H6;  /**< dig_H6 cal register. */
 } bmp280_calib_data;
 
 /**


### PR DESCRIPTION
The BMP280 does not have a humidity sensor, so we don't need
to keep space for compensation values (we don't read them
anyway).
