### PR TITLE
Implement getStatus() and reset()

### DIFF
--- a/Adafruit_BMP280.cpp
+++ b/Adafruit_BMP280.cpp
@@ -412,3 +412,11 @@ void Adafruit_BMP280::takeForcedMeasurement()
     }
 }
 */
+
+void Adafruit_BMP280::reset(void) {
+  write8(BMP280_REGISTER_SOFTRESET, MODE_SOFT_RESET_CODE);
+}
+
+uint8_t Adafruit_BMP280::getStatus(void) {
+  return read8(BMP280_REGISTER_STATUS);
+}

--- a/Adafruit_BMP280.cpp
+++ b/Adafruit_BMP280.cpp
@@ -413,10 +413,17 @@ void Adafruit_BMP280::takeForcedMeasurement()
 }
 */
 
+/*!
+ *  @brief  Resets the chip via soft reset
+ */
 void Adafruit_BMP280::reset(void) {
   write8(BMP280_REGISTER_SOFTRESET, MODE_SOFT_RESET_CODE);
 }
 
+/*!
+    @brief  Gets the most recent sensor event from the hardware status register.
+    @return Sensor status as a byte.
+ */
 uint8_t Adafruit_BMP280::getStatus(void) {
   return read8(BMP280_REGISTER_STATUS);
 }

--- a/Adafruit_BMP280.h
+++ b/Adafruit_BMP280.h
@@ -57,6 +57,7 @@ enum {
   BMP280_REGISTER_VERSION = 0xD1,
   BMP280_REGISTER_SOFTRESET = 0xE0,
   BMP280_REGISTER_CAL26 = 0xE1, /**< R calibration = 0xE1-0xF0 */
+  BMP280_REGISTER_STATUS = 0xF3,
   BMP280_REGISTER_CONTROL = 0xF4,
   BMP280_REGISTER_CONFIG = 0xF5,
   BMP280_REGISTER_PRESSUREDATA = 0xF7,
@@ -170,6 +171,10 @@ public:
                    sensor_sampling pressSampling = SAMPLING_X16,
                    sensor_filter filter = FILTER_OFF,
                    standby_duration duration = STANDBY_MS_1);
+
+  void reset(void);
+
+  uint8_t getStatus(void);
   
   TwoWire *_wire; /**< Wire object */
   SPIClass *_spi; /**< SPI object */


### PR DESCRIPTION
After my sensor got disconnected and reconnected the reading was no longer correct. To figure out when this happens I added the getStatus() function. When such an event occurred calling reset() would bring the reading back reliably.

I tested my code on an ESP32 using I2C. Whenever getStatus() reports 0xFF the sensor starts sending valid data again after calling reset(). It appears also begin() needs to be called on the sensor.

I did not test using SPI.