### PR TITLE
Allow user to call TwoWire::begin themselves

### DIFF
--- a/Adafruit_BMP280.cpp
+++ b/Adafruit_BMP280.cpp
@@ -73,14 +73,19 @@ Adafruit_BMP280::Adafruit_BMP280(int8_t cspin, int8_t mosipin, int8_t misopin,
  *         The I2C address to use (default = 0x77)
  *  @param chipid
  *         The expected chip ID (used to validate connection).
+ *  @param beginTwi
+ *         Call begin on the TwoWire object (default = true).
+ *         If false, call TwoWire::begin yourself before calling
+ *         this function.
  *  @return True if the init was successful, otherwise false.
  */
-bool Adafruit_BMP280::begin(uint8_t addr, uint8_t chipid) {
+bool Adafruit_BMP280::begin(uint8_t addr, uint8_t chipid, bool beginTwi) {
   _i2caddr = addr;
 
   if (_cs == -1) {
     // i2c
-    _wire->begin();
+    if (beginTwi)
+      _wire->begin();
   } else {
     digitalWrite(_cs, HIGH);
     pinMode(_cs, OUTPUT);

--- a/Adafruit_BMP280.h
+++ b/Adafruit_BMP280.h
@@ -187,7 +187,8 @@ public:
   Adafruit_BMP280(int8_t cspin, int8_t mosipin, int8_t misopin, int8_t sckpin);
   ~Adafruit_BMP280(void);
 
-  bool begin(uint8_t addr = BMP280_ADDRESS, uint8_t chipid = BMP280_CHIPID);
+  bool begin(uint8_t addr = BMP280_ADDRESS, uint8_t chipid = BMP280_CHIPID,
+             bool beginTwi = true);
   void reset(void);
   uint8_t getStatus(void);
 


### PR DESCRIPTION
* That way, they can use non-default pins and have multiple
  devices on a single TwoWire bus.
