### PR TITLE
Add alternative address to the example code

### DIFF
--- a/examples/bmp280_sensortest/bmp280_sensortest.ino
+++ b/examples/bmp280_sensortest/bmp280_sensortest.ino
@@ -28,8 +28,10 @@ void setup() {
   Serial.begin(9600);
   Serial.println(F("BMP280 Sensor event test"));
 
+  //if (!bmp.begin(BMP280_ADDRESS_ALT, BMP280_CHIPID)) {
   if (!bmp.begin()) {
-    Serial.println(F("Could not find a valid BMP280 sensor, check wiring!"));
+    Serial.println(F("Could not find a valid BMP280 sensor, check wiring or "
+                      "try a different address!"));
     while (1) delay(10);
   }
 

--- a/examples/bmp280test/bmp280test.ino
+++ b/examples/bmp280test/bmp280test.ino
@@ -32,9 +32,11 @@ void setup() {
   Serial.begin(9600);
   Serial.println(F("BMP280 test"));
 
+  //if (!bmp.begin(BMP280_ADDRESS_ALT, BMP280_CHIPID)) {
   if (!bmp.begin()) {
-    Serial.println(F("Could not find a valid BMP280 sensor, check wiring!"));
-    while (1);
+    Serial.println(F("Could not find a valid BMP280 sensor, check wiring or "
+                      "try a different address!"));
+    while (1) delay(10);
   }
 
   /* Default settings from datasheet. */


### PR DESCRIPTION
Changes:
- add commented out code to use the predefined alternative address (0x76)
- add additional info to the error message to try a different address

Added these changes to help resolve the simple issue of the wrong address quicker.