### PR TITLE
add sensorID()

### DIFF
--- a/Adafruit_BMP280.cpp
+++ b/Adafruit_BMP280.cpp
@@ -441,6 +441,12 @@ void Adafruit_BMP280::reset(void) {
 }
 
 /*!
+ *   Returns Sensor ID for diagnostics
+ *   @returns Sensor ID 0x61 for BME680, 0x60 for BME280, 0x56, 0x57, 0x58 for BMP280
+ */
+uint8_t Adafruit_BMP280::sensorID(void) { return read8(BMP280_REGISTER_CHIPID); };
+
+/*!
     @brief  Gets the most recent sensor event from the hardware status register.
     @return Sensor status as a byte.
  */

--- a/Adafruit_BMP280.cpp
+++ b/Adafruit_BMP280.cpp
@@ -442,9 +442,11 @@ void Adafruit_BMP280::reset(void) {
 
 /*!
  *   Returns Sensor ID for diagnostics
- *   @returns Sensor ID 0x61 for BME680, 0x60 for BME280, 0x56, 0x57, 0x58 for BMP280
+ *   @returns 0x61 for BME680, 0x60 for BME280, 0x56, 0x57, 0x58 for BMP280
  */
-uint8_t Adafruit_BMP280::sensorID(void) { return read8(BMP280_REGISTER_CHIPID); };
+uint8_t Adafruit_BMP280::sensorID(void) {
+  return read8(BMP280_REGISTER_CHIPID);
+};
 
 /*!
     @brief  Gets the most recent sensor event from the hardware status register.

--- a/Adafruit_BMP280.h
+++ b/Adafruit_BMP280.h
@@ -190,6 +190,7 @@ public:
   bool begin(uint8_t addr = BMP280_ADDRESS, uint8_t chipid = BMP280_CHIPID);
   void reset(void);
   uint8_t getStatus(void);
+  uint8_t sensorID(void);
 
   float readTemperature();
   float readPressure(void);


### PR DESCRIPTION
This pull request adds a sensorID() function to the BMP280 library.
sensorID() returns 0x61 for BME680, 0x60 for BME280, 0x56, 0x57, 0x58 for BMP280, and 0x0 if the sensor is no longer plugged in. I use this to check if a sensor is still responsive.


