### PR TITLE
Tweak memory alloc and cleanup

### DIFF
--- a/Adafruit_BMP280.cpp
+++ b/Adafruit_BMP280.cpp
@@ -34,8 +34,10 @@ Adafruit_BMP280::Adafruit_BMP280(TwoWire *theWire) {
 }
 
 Adafruit_BMP280::~Adafruit_BMP280(void) {
-  if (spi_dev) delete spi_dev;
-  if (i2c_dev) delete i2c_dev;
+  if (spi_dev)
+    delete spi_dev;
+  if (i2c_dev)
+    delete i2c_dev;
   delete temp_sensor;
   delete pressure_sensor;
 }

--- a/Adafruit_BMP280.cpp
+++ b/Adafruit_BMP280.cpp
@@ -34,6 +34,8 @@ Adafruit_BMP280::Adafruit_BMP280(TwoWire *theWire) {
 }
 
 Adafruit_BMP280::~Adafruit_BMP280(void) {
+  if (spi_dev) delete spi_dev;
+  if (i2c_dev) delete i2c_dev;
   delete temp_sensor;
   delete pressure_sensor;
 }
@@ -80,10 +82,14 @@ Adafruit_BMP280::Adafruit_BMP280(int8_t cspin, int8_t mosipin, int8_t misopin,
  */
 bool Adafruit_BMP280::begin(uint8_t addr, uint8_t chipid) {
   if (spi_dev == NULL) {
+    // I2C mode
+    if (i2c_dev)
+      delete i2c_dev;
     i2c_dev = new Adafruit_I2CDevice(addr, _wire);
     if (!i2c_dev->begin())
       return false;
   } else {
+    // SPI mode
     if (!spi_dev->begin())
       return false;
   }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit BMP280 Library
-version=2.4.0
+version=2.4.1
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Arduino library for BMP280 sensors.


### PR DESCRIPTION
Motivated by #57, but not necessarily trying to "fix" that use case. But some amount of checking and cleanup is a good idea.

Torture test sketch run on Qt PY M0:
```cpp
#include <Adafruit_BMP280.h>

Adafruit_BMP280 bmp;

void setup() {
  Serial.begin(9600);
  while (!Serial);
  Serial.println(F("BMP280 multiple begin() call test"));         
}

void loop() {
  if (!bmp.begin()) {
    Serial.println(F("Could not find a valid BMP280 sensor, check wiring or "
                      "try a different address!"));
    while (1) delay(10);
  }

  Serial.print(F("Pressure = "));
  Serial.print(bmp.readPressure());
  Serial.println(" Pa");

  delay(1000);
}
```

At first run:
![Screenshot from 2021-08-23 15-47-30](https://user-images.githubusercontent.com/8755041/130533207-3179f4fc-7893-460d-88ec-96215acb73ba.png)

and still ticking after almost an hour of running:
![Screenshot from 2021-08-23 16-41-31](https://user-images.githubusercontent.com/8755041/130533232-ea7c7d15-114f-4b22-9f0b-3abe22c6ae79.png)

