### PR TITLE
Fix for issue #60 (uninitialized configuration structs)

### DIFF
--- a/Adafruit_BMP280.h
+++ b/Adafruit_BMP280.h
@@ -235,7 +235,8 @@ private:
   /** Encapsulates trhe ctrl_meas register */
   struct ctrl_meas {
     /** Initialize to power-on-reset state */
-    ctrl_meas() : osrs_t(SAMPLING_NONE), osrs_p(SAMPLING_NONE), mode(MODE_SLEEP) {}
+    ctrl_meas()
+        : osrs_t(SAMPLING_NONE), osrs_p(SAMPLING_NONE), mode(MODE_SLEEP) {}
     /** Temperature oversampling. */
     unsigned int osrs_t : 3;
     /** Pressure oversampling. */

--- a/Adafruit_BMP280.h
+++ b/Adafruit_BMP280.h
@@ -218,6 +218,8 @@ private:
 
   /** Encapsulates the config register */
   struct config {
+    /** Initialize to power-on-reset state */
+    config() : t_sb(STANDBY_MS_1), filter(FILTER_OFF), none(0), spi3w_en(0) {}
     /** Inactive duration (standby time) in normal mode */
     unsigned int t_sb : 3;
     /** Filter settings */
@@ -232,6 +234,8 @@ private:
 
   /** Encapsulates trhe ctrl_meas register */
   struct ctrl_meas {
+    /** Initialize to power-on-reset state */
+    ctrl_meas() : osrs_t(SAMPLING_NONE), osrs_p(SAMPLING_NONE), mode(MODE_SLEEP) {}
     /** Temperature oversampling. */
     unsigned int osrs_t : 3;
     /** Pressure oversampling. */


### PR DESCRIPTION
Initialize Adafruit_BMP280::_config and _ctrlMeas members to power-on-reset state in their constructors. Note that Adafruit_BMP280::begin() calls Adafruit_BMP280::setSampling() which will mostly initialize these structs as well. The defect in issue #60 is that _config.spi3w_en is never initialized and consequently the sensor can end up configured for spi 3-wire mode, which is not supported by the code. Fix is to initialize all members of these configuration structs to the power-on-reset values defined in the datasheet.

Testing: ran my local code that demonstrated the defect

Risk: minimal -- setSampling() already initializes all of the struct members save spi3w_en, and if that member is ever non-zero the sensor is put into a mode not supported by this library!