### PR TITLE
Match BME 280 library behaviour on sensorID

### DIFF
--- a/Adafruit_BMP280.cpp
+++ b/Adafruit_BMP280.cpp
@@ -96,7 +96,9 @@ bool Adafruit_BMP280::begin(uint8_t addr, uint8_t chipid) {
       return false;
   }
 
-  if (read8(BMP280_REGISTER_CHIPID) != chipid)
+  // check if sensor, i.e. the chip ID is correct
+  _sensorID = read8(BMP280_REGISTER_CHIPID);
+  if (_sensorID != chipid)
     return false;
 
   readCoefficients();
@@ -378,7 +380,7 @@ void Adafruit_BMP280::reset(void) {
  *   @returns 0x61 for BME680, 0x60 for BME280, 0x56, 0x57, 0x58 for BMP280
  */
 uint8_t Adafruit_BMP280::sensorID(void) {
-  return read8(BMP280_REGISTER_CHIPID);
+  return _sensorID;
 };
 
 /*!

--- a/Adafruit_BMP280.cpp
+++ b/Adafruit_BMP280.cpp
@@ -379,9 +379,7 @@ void Adafruit_BMP280::reset(void) {
  *   Returns Sensor ID for diagnostics
  *   @returns 0x61 for BME680, 0x60 for BME280, 0x56, 0x57, 0x58 for BMP280
  */
-uint8_t Adafruit_BMP280::sensorID(void) {
-  return _sensorID;
-};
+uint8_t Adafruit_BMP280::sensorID(void) { return _sensorID; };
 
 /*!
     @brief  Gets the most recent sensor event from the hardware status register.

--- a/Adafruit_BMP280.h
+++ b/Adafruit_BMP280.h
@@ -259,7 +259,7 @@ private:
 
   uint8_t _i2caddr;
 
-  int32_t _sensorID;
+  int32_t _sensorID = 0;
   int32_t t_fine;
   // int8_t _cs, _mosi, _miso, _sck;
   bmp280_calib_data _bmp280_calib;

--- a/examples/bmp280_sensortest/bmp280_sensortest.ino
+++ b/examples/bmp280_sensortest/bmp280_sensortest.ino
@@ -26,12 +26,20 @@ Adafruit_Sensor *bmp_pressure = bmp.getPressureSensor();
 
 void setup() {
   Serial.begin(9600);
+  while(!Serial);       // time to get serial running
   Serial.println(F("BMP280 Sensor event test"));
 
-  //if (!bmp.begin(BMP280_ADDRESS_ALT, BMP280_CHIPID)) {
-  if (!bmp.begin()) {
+  unsigned status;
+  //status = bmp.begin(BMP280_ADDRESS_ALT, BMP280_CHIPID);
+  status = bmp.begin(0x76);
+  if (!status) {
     Serial.println(F("Could not find a valid BMP280 sensor, check wiring or "
                       "try a different address!"));
+    Serial.print("SensorID was: 0x"); Serial.println(bmp.sensorID(),16);
+    Serial.print("        ID of 0xFF probably means a bad address, a BMP 180 or BMP 085\n");
+    Serial.print("   ID of 0x56-0x58 represents a BMP 280,\n");
+    Serial.print("        ID of 0x60 represents a BME 280.\n");
+    Serial.print("        ID of 0x61 represents a BME 680.\n");
     while (1) delay(10);
   }
 

--- a/examples/bmp280_sensortest/bmp280_sensortest.ino
+++ b/examples/bmp280_sensortest/bmp280_sensortest.ino
@@ -26,12 +26,12 @@ Adafruit_Sensor *bmp_pressure = bmp.getPressureSensor();
 
 void setup() {
   Serial.begin(9600);
-  while(!Serial);       // time to get serial running
+  while ( !Serial ) delay(100);   // wait for native usb
   Serial.println(F("BMP280 Sensor event test"));
 
   unsigned status;
   //status = bmp.begin(BMP280_ADDRESS_ALT, BMP280_CHIPID);
-  status = bmp.begin(0x76);
+  status = bmp.begin();
   if (!status) {
     Serial.println(F("Could not find a valid BMP280 sensor, check wiring or "
                       "try a different address!"));

--- a/examples/bmp280test/bmp280test.ino
+++ b/examples/bmp280test/bmp280test.ino
@@ -30,12 +30,19 @@ Adafruit_BMP280 bmp; // I2C
 
 void setup() {
   Serial.begin(9600);
+  while(!Serial);       // time to get serial running
   Serial.println(F("BMP280 test"));
-
-  //if (!bmp.begin(BMP280_ADDRESS_ALT, BMP280_CHIPID)) {
-  if (!bmp.begin()) {
+  unsigned status;
+  //status = bmp.begin(BMP280_ADDRESS_ALT, BMP280_CHIPID);
+  status = bmp.begin(0x76);
+  if (!status) {
     Serial.println(F("Could not find a valid BMP280 sensor, check wiring or "
                       "try a different address!"));
+    Serial.print("SensorID was: 0x"); Serial.println(bmp.sensorID(),16);
+    Serial.print("        ID of 0xFF probably means a bad address, a BMP 180 or BMP 085\n");
+    Serial.print("   ID of 0x56-0x58 represents a BMP 280,\n");
+    Serial.print("        ID of 0x60 represents a BME 280.\n");
+    Serial.print("        ID of 0x61 represents a BME 680.\n");
     while (1) delay(10);
   }
 

--- a/examples/bmp280test/bmp280test.ino
+++ b/examples/bmp280test/bmp280test.ino
@@ -30,11 +30,11 @@ Adafruit_BMP280 bmp; // I2C
 
 void setup() {
   Serial.begin(9600);
-  while(!Serial);       // time to get serial running
+  while ( !Serial ) delay(100);   // wait for native usb
   Serial.println(F("BMP280 test"));
   unsigned status;
   //status = bmp.begin(BMP280_ADDRESS_ALT, BMP280_CHIPID);
-  status = bmp.begin(0x76);
+  status = bmp.begin();
   if (!status) {
     Serial.println(F("Could not find a valid BMP280 sensor, check wiring or "
                       "try a different address!"));


### PR DESCRIPTION
Initializes existing _sensorID variable to zero, then sets it during begin()

sensorID() now returns _sensorID detected when running begin()

Test example code provides more diagnostic information when begin fails and waits for Serial to initialize so the output isn't lost.

No known limitations. The Adafruit BME280 library has contained similar code for an extended period of time.
