### PR TITLE
Fix issue #67 printSensorDetails() issue

### DIFF
--- a/Adafruit_BMP280.cpp
+++ b/Adafruit_BMP280.cpp
@@ -37,7 +37,7 @@ Adafruit_BMP280::~Adafruit_BMP280(void) {
     delete spi_dev;
   if (i2c_dev)
     delete i2c_dev;
-  if (temp_sensor == nullptr) 
+  if (temp_sensor == nullptr)
     delete temp_sensor;
   if (pressure_sensor == nullptr)
     delete pressure_sensor;

--- a/Adafruit_BMP280.cpp
+++ b/Adafruit_BMP280.cpp
@@ -37,8 +37,8 @@ Adafruit_BMP280::~Adafruit_BMP280(void) {
     delete spi_dev;
   if (i2c_dev)
     delete i2c_dev;
-  delete temp_sensor;
-  delete pressure_sensor;
+  // delete temp_sensor;
+  // delete pressure_sensor;
 }
 
 /*!

--- a/Adafruit_BMP280.cpp
+++ b/Adafruit_BMP280.cpp
@@ -33,9 +33,9 @@ Adafruit_BMP280::Adafruit_BMP280(TwoWire *theWire) {
 }
 
 Adafruit_BMP280::~Adafruit_BMP280(void) {
-  if (spi_dev)
+  if (spi_dev == nullptr)
     delete spi_dev;
-  if (i2c_dev)
+  if (i2c_dev == nullptr)
     delete i2c_dev;
   if (temp_sensor == nullptr)
     delete temp_sensor;

--- a/Adafruit_BMP280.cpp
+++ b/Adafruit_BMP280.cpp
@@ -37,8 +37,10 @@ Adafruit_BMP280::~Adafruit_BMP280(void) {
     delete spi_dev;
   if (i2c_dev)
     delete i2c_dev;
-  if (temp_sensor == nullptr) delete temp_sensor;
-  if (pressure_sensor == nullptr) delete pressure_sensor;
+  if (temp_sensor == nullptr) 
+    delete temp_sensor;
+  if (pressure_sensor == nullptr)
+    delete pressure_sensor;
 }
 
 /*!

--- a/Adafruit_BMP280.cpp
+++ b/Adafruit_BMP280.cpp
@@ -37,8 +37,6 @@ Adafruit_BMP280::~Adafruit_BMP280(void) {
     delete spi_dev;
   if (i2c_dev)
     delete i2c_dev;
-  // delete temp_sensor;
-  // delete pressure_sensor;
 }
 
 /*!

--- a/Adafruit_BMP280.cpp
+++ b/Adafruit_BMP280.cpp
@@ -33,9 +33,9 @@ Adafruit_BMP280::Adafruit_BMP280(TwoWire *theWire) {
 }
 
 Adafruit_BMP280::~Adafruit_BMP280(void) {
-  if (spi_dev == nullptr)
+  if (spi_dev)
     delete spi_dev;
-  if (i2c_dev == nullptr)
+  if (i2c_dev)
     delete i2c_dev;
   if (temp_sensor == nullptr)
     delete temp_sensor;

--- a/Adafruit_BMP280.cpp
+++ b/Adafruit_BMP280.cpp
@@ -37,6 +37,8 @@ Adafruit_BMP280::~Adafruit_BMP280(void) {
     delete spi_dev;
   if (i2c_dev)
     delete i2c_dev;
+  if (temp_sensor == nullptr) delete temp_sensor;
+  if (pressure_sensor == nullptr) delete pressure_sensor;
 }
 
 /*!


### PR DESCRIPTION
## Overview

This pull request fix the issue #67 

## TODO

- [x] removed unnecesary deleted objects directives (temperature and pressure)
- [x] tested on M5StickC with two Wire objects (two i2c Wire and Wire1)
- [x] tested with senser hat env II

## Output:

```python
22:31:17.229 > == CanAirIO Setup ==
22:31:17.233 > 
22:31:17.237 > -->[CONF] dM5StickCPlus initializing...OK
22:31:18.157 > -->[TGUI] display config ready.
22:31:18.181 > -->[TGUI] displayed welcome screen
22:31:18.181 > -->[HEAP] GUI  bytes used        : 0476b/230Kb
22:31:18.185 > -->[INFO] ESP32MAC:      94:B9:7E:8C:83:CA
22:31:18.189 > -->[INFO] Hostname:      CanAirIO3CA
22:31:18.193 > -->[INFO] Revision:      r884
22:31:18.193 > -->[INFO] Firmware:      0.5.1
22:31:18.197 > -->[INFO] Flavor  :      M5STICKCPLUS
22:31:18.201 > -->[INFO] Target  :      dev
22:31:18.201 > -->[INFO] Detecting sensors:
22:31:18.205 > -->[INFO] Sensorslib version     : 0.4.4
22:31:18.209 > -->[INFO] enable sensor GPIO     : 27
22:31:18.213 > -->[HEAP] GPIO bytes used        : 0000b/230Kb
22:31:18.213 > -->[INFO] config UART sensor     : 0
22:31:18.309 > -->[SLIB] new sample time        : 1
22:31:18.309 > -->[SLIB] Sensorlib version      : 0.4.4
22:31:18.313 > -->[SLIB] Sensorlib revision     : 342
22:31:18.317 > -->[SLIB] Sensorlib debug mode   : enable
22:31:18.321 > -->[SLIB] temperature offset     : 5.90
22:31:18.325 > -->[SLIB] altitude offset        : 0.00
22:31:18.325 > -->[SLIB] only i2c sensors       : 1
22:31:18.329 > -->[SLIB] try to enable sensor   : I2C SPS30.. 
22:31:18.333 > [E][SLIB] SPS30 could not probe. 
22:31:18.337 > -->[SLIB] try to enable sensor   : PANASONIC GCJA5.. 
22:31:18.341 > -->[SLIB] I2C sensor detected    : SN-GCJA5
22:31:18.345 > -->[SLIB] GCJA5 FAN status       : 0
22:31:18.349 > -->[SLIB] try to enable sensor   : AM2320.. 
22:31:18.353 > -->[SLIB] try to enable sensor   : SHT31.. 
22:31:18.357 > -->[SLIB] I2C sensor detected    : SHT31
22:31:18.361 > -->[SLIB] try to enable sensor   : BME280.. 
22:31:18.365 > -->[SLIB] try to enable sensor   : BMP280.. 
22:31:18.461 > -->[SLIB] I2C sensor detected    : BMP280
22:31:18.465 > ------------------------------------
22:31:18.469 > Sensor:       BMP280
22:31:18.469 > Type:         Ambient Temp (C)
22:31:18.473 > Driver Ver:   1
22:31:18.473 > Unique ID:    280
22:31:18.477 > Min Value:    -40.00
22:31:18.477 > Max Value:    85.00
22:31:18.481 > Resolution:   0.01
22:31:18.481 > ------------------------------------
22:31:18.485 > 
22:31:18.485 > ------------------------------------
22:31:18.489 > Sensor:       BMP280
22:31:18.489 > Type:         Pressure (hPa)
22:31:18.493 > Driver Ver:   1
22:31:18.493 > Unique ID:    0
22:31:18.497 > Min Value:    300.00
22:31:18.497 > Max Value:    1100.00
22:31:18.501 > Resolution:   0.01
22:31:18.501 > ------------------------------------
22:31:18.505 > 
```