### PR TITLE
destructor bug fix to the pull request #68 / issue #67

### DIFF
--- a/Adafruit_BMP280.cpp
+++ b/Adafruit_BMP280.cpp
@@ -32,17 +32,6 @@ Adafruit_BMP280::Adafruit_BMP280(TwoWire *theWire) {
   pressure_sensor = new Adafruit_BMP280_Pressure(this);
 }
 
-Adafruit_BMP280::~Adafruit_BMP280(void) {
-  if (spi_dev)
-    delete spi_dev;
-  if (i2c_dev)
-    delete i2c_dev;
-  if (temp_sensor)
-    delete temp_sensor;
-  if (pressure_sensor)
-    delete pressure_sensor;
-}
-
 /*!
  * @brief  BMP280 constructor using hardware SPI
  * @param  cspin
@@ -73,6 +62,17 @@ Adafruit_BMP280::Adafruit_BMP280(int8_t cspin, int8_t mosipin, int8_t misopin,
   spi_dev = new Adafruit_SPIDevice(cspin, sckpin, misopin, mosipin);
   temp_sensor = new Adafruit_BMP280_Temp(this);
   pressure_sensor = new Adafruit_BMP280_Pressure(this);
+}
+
+Adafruit_BMP280::~Adafruit_BMP280(void) {
+  if (spi_dev)
+    delete spi_dev;
+  if (i2c_dev)
+    delete i2c_dev;
+  if (temp_sensor)
+    delete temp_sensor;
+  if (pressure_sensor)
+    delete pressure_sensor;
 }
 
 /*!

--- a/Adafruit_BMP280.cpp
+++ b/Adafruit_BMP280.cpp
@@ -37,9 +37,9 @@ Adafruit_BMP280::~Adafruit_BMP280(void) {
     delete spi_dev;
   if (i2c_dev)
     delete i2c_dev;
-  if (temp_sensor == nullptr)
+  if (temp_sensor)
     delete temp_sensor;
-  if (pressure_sensor == nullptr)
+  if (pressure_sensor)
     delete pressure_sensor;
 }
 


### PR DESCRIPTION
In the destructor (Adafruit_BMP280::~Adafruit_BMP280), delete the objects only when they exist as mentioned in this [comment](https://github.com/adafruit/Adafruit_BMP280_Library/issues/67#issuecomment-1035639564).

In addition, I have placed the destructor after all constructors for the better code readability.