### PR TITLE
Update Adafruit_BMP280.h

### DIFF
--- a/Adafruit_BMP280.h
+++ b/Adafruit_BMP280.h
@@ -32,8 +32,7 @@
  *  I2C ADDRESS/BITS/SETTINGS
  */
 #define BMP280_ADDRESS (0x77) /**< The default I2C address for the sensor. */
-#define BMP280_ADDRESS_ALT                                                     \
-  (0x76)                     /**< Alternative I2C address for the sensor. */
+#define BMP280_ADDRESS_ALT (0x76) /**< Alternative I2C address for the sensor. */
 #define BMP280_CHIPID (0x58) /**< Default chip ID. */
 
 /*!


### PR DESCRIPTION
Line 35 + 36 fixed - something was messed up with this 2 lines so the alternative address was not working